### PR TITLE
Added formspree example to contact page (unstyled)

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -5,6 +5,17 @@ layout: default
     <article class="module color-3">
             <h1>Contact</h1>
             <hr>
-            <p>Contact info.</p>
-    </article>
+
+            <!-- Testing Formspree contact form -->
+
+               <p> To contact us send an email to <a href="mailto:evlug@example.com">evlug@example.com</a> or use the form below.</p>
+
+               <form method="POST" action="////formspree.io/evlug@example.com">
+                   <input type="email" name="_replyto" placeholder="Your email" />
+                   <textarea name="message" rows="5" placeholder="Your message"></textarea>
+                   <input type="text" name="_gotcha" style="display:none">
+                   <button type="submit">Send</button>
+               </form>
+
+   </article>
 </div>


### PR DESCRIPTION
forspree allows you to do forms for email using their api, so no need for a backend. You do have to confirm to configure once you enter the correct address which basically verifies you email and matches the email to a to your Base URL.

The registration looks like so:
![screen shot 2015-07-18 at 12 59 20 am](https://cloud.githubusercontent.com/assets/3722310/8760585/0a32750e-2ceb-11e5-8229-69d685d8d3af.png)

You add you content then once you deploy to production you register the email with formspree which ties it to your URL. This is done by sending and a test email to your self and in turn you get a confirmation email to the linked email for verification, and your set. 
